### PR TITLE
Add simple interface to get message with correlationId from a fixed queue

### DIFF
--- a/commons-jms-api/src/main/java/co/com/bancolombia/commons/jms/api/MQMessageSelectorListener.java
+++ b/commons-jms-api/src/main/java/co/com/bancolombia/commons/jms/api/MQMessageSelectorListener.java
@@ -1,0 +1,12 @@
+package co.com.bancolombia.commons.jms.api;
+
+import reactor.core.publisher.Mono;
+
+import javax.jms.Destination;
+import javax.jms.Message;
+
+public interface MQMessageSelectorListener {
+    Mono<Message> getMessage(String correlationId);
+
+    Mono<Message> getMessage(String correlationId, long timeout, Destination destination);
+}

--- a/commons-jms-api/src/main/java/co/com/bancolombia/commons/jms/api/MQMessageSelectorListenerSync.java
+++ b/commons-jms-api/src/main/java/co/com/bancolombia/commons/jms/api/MQMessageSelectorListenerSync.java
@@ -1,0 +1,10 @@
+package co.com.bancolombia.commons.jms.api;
+
+import javax.jms.Destination;
+import javax.jms.Message;
+
+public interface MQMessageSelectorListenerSync {
+    Message getMessage(String correlationId);
+
+    Message getMessage(String correlationId, long timeout, Destination destination);
+}

--- a/commons-jms-api/src/main/java/co/com/bancolombia/commons/jms/api/exceptions/ReceiveTimeoutException.java
+++ b/commons-jms-api/src/main/java/co/com/bancolombia/commons/jms/api/exceptions/ReceiveTimeoutException.java
@@ -1,0 +1,8 @@
+package co.com.bancolombia.commons.jms.api.exceptions;
+
+public class ReceiveTimeoutException extends RuntimeException {
+
+    public ReceiveTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/commons-jms-mq/src/main/java/co/com/bancolombia/commons/jms/mq/EnableMQSelectorMessageListener.java
+++ b/commons-jms-mq/src/main/java/co/com/bancolombia/commons/jms/mq/EnableMQSelectorMessageListener.java
@@ -1,0 +1,13 @@
+package co.com.bancolombia.commons.jms.mq;
+
+import co.com.bancolombia.commons.jms.mq.config.MQAutoconfigurationSelectorListener;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(MQAutoconfigurationSelectorListener.class)
+public @interface EnableMQSelectorMessageListener {
+}

--- a/commons-jms-mq/src/main/java/co/com/bancolombia/commons/jms/mq/config/MQAutoconfigurationSelectorListener.java
+++ b/commons-jms-mq/src/main/java/co/com/bancolombia/commons/jms/mq/config/MQAutoconfigurationSelectorListener.java
@@ -1,0 +1,51 @@
+package co.com.bancolombia.commons.jms.mq.config;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListener;
+import co.com.bancolombia.commons.jms.api.MQQueueCustomizer;
+import co.com.bancolombia.commons.jms.internal.listener.selector.MQMultiContextMessageSelectorListener;
+import co.com.bancolombia.commons.jms.internal.listener.selector.MQMultiContextMessageSelectorListenerSync;
+import co.com.bancolombia.commons.jms.internal.models.MQListenerConfig;
+import co.com.bancolombia.commons.jms.mq.config.exceptions.MQInvalidSenderException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+import javax.jms.ConnectionFactory;
+
+@Log4j2
+public class MQAutoconfigurationSelectorListener {
+
+    @Bean
+    @ConditionalOnMissingBean(MQMessageSelectorListener.class)
+    @ConditionalOnProperty(prefix = "commons.jms", name = "reactive", havingValue = "true")
+    public MQMessageSelectorListener defaultMQMessageSelectorListener(
+            MQMultiContextMessageSelectorListenerSync senderSync) {
+        return new MQMultiContextMessageSelectorListener(senderSync);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MQMultiContextMessageSelectorListenerSync.class)
+    public MQMultiContextMessageSelectorListenerSync defaultMQMultiContextMessageSelectorListenerSync(
+            ConnectionFactory cf, MQListenerConfig config) {
+        if (config.getConcurrency() < 1) {
+            throw new MQInvalidSenderException("Invalid property commons.jms.input-concurrency, minimum value 1, " +
+                    "you have passed " + config.getConcurrency());
+        }
+        if (log.isInfoEnabled()) {
+            log.info("Creating {} listeners", config.getConcurrency());
+        }
+        return new MQMultiContextMessageSelectorListenerSync(cf, config);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(MQListenerConfig.class)
+    public MQListenerConfig defaultMQListenerConfig(MQProperties properties, MQQueueCustomizer customizer) {
+        return MQListenerConfig.builder()
+                .concurrency(properties.getInputConcurrency())
+                .queue(properties.getInputQueue())
+                .customizer(customizer)
+                .build();
+    }
+
+}

--- a/commons-jms-mq/src/test/java/co/com/bancolombia/commons/jms/mq/config/MQAutoconfigurationSelectorListenerTest.java
+++ b/commons-jms-mq/src/test/java/co/com/bancolombia/commons/jms/mq/config/MQAutoconfigurationSelectorListenerTest.java
@@ -1,0 +1,5 @@
+package co.com.bancolombia.commons.jms.mq.config;
+
+public class MQAutoconfigurationSelectorListenerTest {
+
+}

--- a/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQContextMessageSelectorListenerSync.java
+++ b/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQContextMessageSelectorListenerSync.java
@@ -1,0 +1,38 @@
+package co.com.bancolombia.commons.jms.internal.listener.selector;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListenerSync;
+import co.com.bancolombia.commons.jms.api.exceptions.ReceiveTimeoutException;
+import co.com.bancolombia.commons.jms.internal.models.MQListenerConfig;
+import co.com.bancolombia.commons.jms.utils.MQQueueUtils;
+
+import javax.jms.*;
+
+public class MQContextMessageSelectorListenerSync implements MQMessageSelectorListenerSync {
+    public static final long DEFAULT_TIMEOUT = 5000L;
+    private final JMSContext context;
+    private final Destination destination;
+
+    public MQContextMessageSelectorListenerSync(ConnectionFactory connectionFactory, MQListenerConfig config) {
+        context = connectionFactory.createContext();
+        destination = MQQueueUtils.setupFixedQueue(context, config);
+    }
+
+    public Message getMessage(String correlationId) {
+        return getMessage(correlationId, DEFAULT_TIMEOUT, destination);
+    }
+
+    public Message getMessage(String correlationId, long timeout, Destination destination) {
+        try (JMSConsumer consumer = context.createConsumer(destination, buildSelector(correlationId))) {
+            Message message = consumer.receive(timeout);
+            if (message == null) {
+                throw new ReceiveTimeoutException("Message not received in " + timeout);
+            }
+            return message;
+        }
+    }
+
+    private String buildSelector(String correlationId) {
+        return "JMSCorrelationID='" + correlationId + "'";
+    }
+
+}

--- a/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListener.java
+++ b/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListener.java
@@ -1,0 +1,27 @@
+package co.com.bancolombia.commons.jms.internal.listener.selector;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListener;
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListenerSync;
+import lombok.AllArgsConstructor;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import javax.jms.Destination;
+import javax.jms.Message;
+
+@AllArgsConstructor
+public class MQMultiContextMessageSelectorListener implements MQMessageSelectorListener {
+    private final MQMessageSelectorListenerSync listenerSync; // MQMultiContextMessageSelectorListenerSync
+
+    @Override
+    public Mono<Message> getMessage(String correlationId) {
+        return Mono.defer(() -> Mono.just(listenerSync.getMessage(correlationId)))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
+    public Mono<Message> getMessage(String correlationId, long timeout, Destination destination) {
+        return Mono.defer(() -> Mono.just(listenerSync.getMessage(correlationId, timeout, destination)))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+}

--- a/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListenerSync.java
+++ b/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListenerSync.java
@@ -1,0 +1,40 @@
+package co.com.bancolombia.commons.jms.internal.listener.selector;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListenerSync;
+import co.com.bancolombia.commons.jms.internal.models.MQListenerConfig;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.Message;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class MQMultiContextMessageSelectorListenerSync implements MQMessageSelectorListenerSync {
+    private final ConnectionFactory connectionFactory;
+    private final MQListenerConfig config;
+    private List<MQContextMessageSelectorListenerSync> adapterList;
+
+    public MQMultiContextMessageSelectorListenerSync(ConnectionFactory connectionFactory, MQListenerConfig config) {
+        this.connectionFactory = connectionFactory;
+        this.config = config;
+        start();
+    }
+
+    public void start() {
+        adapterList = IntStream.range(0, config.getConcurrency())
+                .mapToObj(idx -> new MQContextMessageSelectorListenerSync(connectionFactory, config))
+                .collect(Collectors.toList());
+    }
+
+    public Message getMessage(String correlationId) {
+        int selectIndex = (int) (System.currentTimeMillis() % config.getConcurrency());
+        return adapterList.get(selectIndex).getMessage(correlationId);
+    }
+
+    public Message getMessage(String correlationId, long timeout, Destination destination) {
+        int selectIndex = (int) (System.currentTimeMillis() % config.getConcurrency());
+        return adapterList.get(selectIndex).getMessage(correlationId, timeout, destination);
+    }
+
+}

--- a/commons-jms-utils/src/test/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListenerSyncTest.java
+++ b/commons-jms-utils/src/test/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListenerSyncTest.java
@@ -1,0 +1,73 @@
+package co.com.bancolombia.commons.jms.internal.listener.selector;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListenerSync;
+import co.com.bancolombia.commons.jms.api.exceptions.ReceiveTimeoutException;
+import co.com.bancolombia.commons.jms.internal.models.MQListenerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.jms.*;
+import java.util.UUID;
+
+import static co.com.bancolombia.commons.jms.internal.listener.selector.MQContextMessageSelectorListenerSync.DEFAULT_TIMEOUT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class MQMultiContextMessageSelectorListenerSyncTest {
+    @Mock
+    private ConnectionFactory connectionFactory;
+    @Mock
+    private JMSContext context;
+    @Mock
+    private JMSConsumer consumer;
+    @Mock
+    private Queue queue;
+    @Mock
+    private TextMessage message;
+
+    private MQMessageSelectorListenerSync listenerSync;
+
+    @BeforeEach
+    void setup() {
+        when(connectionFactory.createContext()).thenReturn(context);
+        when(context.createQueue(anyString())).thenReturn(queue);
+        MQListenerConfig config = MQListenerConfig
+                .builder()
+                .concurrency(1)
+                .queue("QUEUE")
+                .build();
+        listenerSync = new MQMultiContextMessageSelectorListenerSync(connectionFactory, config);
+    }
+
+    @Test
+    void shouldGetMessage() {
+        // Arrange
+        String messageID = UUID.randomUUID().toString();
+        when(context.createConsumer(any(Destination.class), anyString())).thenReturn(consumer);
+        when(consumer.receive(DEFAULT_TIMEOUT)).thenReturn(message);
+        // Act
+        Message receivedMessage = listenerSync.getMessage(messageID);
+        // Assert
+        assertEquals(message, receivedMessage);
+        verify(consumer, times(1)).receive(DEFAULT_TIMEOUT);
+    }
+
+    @Test
+    void shouldHandleTimeoutErrorWithCustomTimeout() {
+        // Arrange
+        String messageID = UUID.randomUUID().toString();
+        when(context.createConsumer(any(Destination.class), anyString())).thenReturn(consumer);
+        when(consumer.receive(DEFAULT_TIMEOUT)).thenReturn(null);
+        // Act
+        // Assert
+        assertThrows(ReceiveTimeoutException.class, () -> listenerSync.getMessage(messageID, DEFAULT_TIMEOUT, queue));
+    }
+
+}

--- a/commons-jms-utils/src/test/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListenerTest.java
+++ b/commons-jms-utils/src/test/java/co/com/bancolombia/commons/jms/internal/listener/selector/MQMultiContextMessageSelectorListenerTest.java
@@ -1,0 +1,81 @@
+package co.com.bancolombia.commons.jms.internal.listener.selector;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListener;
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListenerSync;
+import co.com.bancolombia.commons.jms.api.exceptions.ReceiveTimeoutException;
+import co.com.bancolombia.commons.jms.internal.models.MQListenerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import javax.jms.*;
+import java.util.UUID;
+
+import static co.com.bancolombia.commons.jms.internal.listener.selector.MQContextMessageSelectorListenerSync.DEFAULT_TIMEOUT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class MQMultiContextMessageSelectorListenerTest {
+    @Mock
+    private ConnectionFactory connectionFactory;
+    @Mock
+    private JMSContext context;
+    @Mock
+    private JMSConsumer consumer;
+    @Mock
+    private Queue queue;
+    @Mock
+    private TextMessage message;
+
+    private MQMessageSelectorListener listener;
+
+    @BeforeEach
+    void setup() {
+        when(connectionFactory.createContext()).thenReturn(context);
+        when(context.createQueue(anyString())).thenReturn(queue);
+        MQListenerConfig config = MQListenerConfig.builder()
+                .concurrency(1)
+                .queue("QUEUE")
+                .build();
+        MQMessageSelectorListenerSync listenerSync =
+                new MQMultiContextMessageSelectorListenerSync(connectionFactory, config);
+        listener = new MQMultiContextMessageSelectorListener(listenerSync);
+    }
+
+    @Test
+    void shouldGetMessage() {
+        // Arrange
+        String messageID = UUID.randomUUID().toString();
+        when(context.createConsumer(any(Destination.class), anyString())).thenReturn(consumer);
+        when(consumer.receive(DEFAULT_TIMEOUT)).thenReturn(message);
+        // Act
+        Mono<Message> receiveMessage = listener.getMessage(messageID);
+        // Assert
+        StepVerifier.create(receiveMessage)
+                .assertNext(receivedMessage -> assertEquals(message, receivedMessage))
+                .verifyComplete();
+        verify(consumer, times(1)).receive(DEFAULT_TIMEOUT);
+    }
+
+    @Test
+    void shouldHandleTimeoutErrorWithCustomTimeout() {
+        // Arrange
+        String messageID = UUID.randomUUID().toString();
+        when(context.createConsumer(any(Destination.class), anyString())).thenReturn(consumer);
+        when(consumer.receive(DEFAULT_TIMEOUT)).thenReturn(null);
+        // Act
+        Mono<Message> receiveMessage = listener.getMessage(messageID, DEFAULT_TIMEOUT, queue);
+        // Assert
+        StepVerifier.create(receiveMessage)
+                .expectError(ReceiveTimeoutException.class)
+                .verify();
+    }
+
+}

--- a/examples/mq-reactive-selector/README.md
+++ b/examples/mq-reactive-selector/README.md
@@ -1,0 +1,14 @@
+# MQ Sample
+
+To run this sample you need to run a MQ Server.
+
+You can do it with docker, please refer to [docker hub](https://hub.docker.com/r/ibmcom/mq) for more details:
+
+```shell
+docker run -e LICENSE=accept -e MQ_QMGR_NAME=QM1 -p 1414:1414 -p 9443:9443 -d --name ibmmq -e MQ_APP_PASSWORD=passw0rd ibmcom/mq
+```
+
+When MQ Server is running, run
+this [MainApplication](src/main/java/co/com/bancolombia/jms/sample/app/MainApplication.java)
+
+Visit this [http://localhost:8080/api/mq](http://localhost:8080/api/mq) to send and listen a message.

--- a/examples/mq-reactive-selector/mq-reactive-selector.gradle
+++ b/examples/mq-reactive-selector/mq-reactive-selector.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    compile 'org.springframework.boot:spring-boot-starter-webflux'
+    compile project(':commons-jms-mq')
+}
+
+install {
+    enabled false
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/app/MainApplication.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/app/MainApplication.java
@@ -1,0 +1,11 @@
+package co.com.bancolombia.jms.sample.selector.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "co.com.bancolombia")
+public class MainApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MainApplication.class);
+    }
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/app/config/Config.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/app/config/Config.java
@@ -1,0 +1,14 @@
+package co.com.bancolombia.jms.sample.selector.app.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Config {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/app/config/UseCasesConfig.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/app/config/UseCasesConfig.java
@@ -1,0 +1,14 @@
+package co.com.bancolombia.jms.sample.selector.app.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+@Configuration
+@ComponentScan(basePackages = "co.com.bancolombia.jms.sample.selector.domain.usecase",
+        includeFilters = {
+                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+UseCase$")
+        },
+        useDefaultFilters = false)
+public class UseCasesConfig {
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/exceptions/ParseMessageException.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/exceptions/ParseMessageException.java
@@ -1,0 +1,7 @@
+package co.com.bancolombia.jms.sample.selector.domain.exceptions;
+
+public class ParseMessageException extends RuntimeException {
+    public ParseMessageException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/model/Request.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/model/Request.java
@@ -1,0 +1,15 @@
+package co.com.bancolombia.jms.sample.selector.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Request {
+    private String id;
+    private long createdAt;
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/model/RequestGateway.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/model/RequestGateway.java
@@ -1,0 +1,9 @@
+package co.com.bancolombia.jms.sample.selector.domain.model;
+
+import reactor.core.publisher.Mono;
+
+public interface RequestGateway {
+    Mono<String> send(Request request);
+
+    Mono<Result> getResult(String correlationId);
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/model/Result.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/model/Result.java
@@ -1,0 +1,15 @@
+package co.com.bancolombia.jms.sample.selector.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Result {
+    private String request;
+    private long takenTime;
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/usecase/SampleUseCase.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/domain/usecase/SampleUseCase.java
@@ -1,0 +1,26 @@
+package co.com.bancolombia.jms.sample.selector.domain.usecase;
+
+import co.com.bancolombia.jms.sample.selector.domain.model.Request;
+import co.com.bancolombia.jms.sample.selector.domain.model.RequestGateway;
+import co.com.bancolombia.jms.sample.selector.domain.model.Result;
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Mono;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Log4j2
+@AllArgsConstructor
+public class SampleUseCase {
+    private final RequestGateway gateway;
+
+    public Mono<Result> sendAndListen() {
+        return gateway.send(Request.builder()
+                        .id(UUID.randomUUID().toString())
+                        .createdAt(new Date().getTime())
+                        .build())
+                .doOnSuccess(id -> log.info("Message sent: {}", id))
+                .flatMap(gateway::getResult);
+    }
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/drivenadapters/MyMQSender.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/drivenadapters/MyMQSender.java
@@ -1,0 +1,68 @@
+package co.com.bancolombia.jms.sample.selector.drivenadapters;
+
+import co.com.bancolombia.commons.jms.api.MQMessageSelectorListener;
+import co.com.bancolombia.commons.jms.api.MQMessageSender;
+import co.com.bancolombia.commons.jms.mq.EnableMQMessageSender;
+import co.com.bancolombia.commons.jms.mq.EnableMQSelectorMessageListener;
+import co.com.bancolombia.jms.sample.selector.domain.exceptions.ParseMessageException;
+import co.com.bancolombia.jms.sample.selector.domain.model.Request;
+import co.com.bancolombia.jms.sample.selector.domain.model.RequestGateway;
+import co.com.bancolombia.jms.sample.selector.domain.model.Result;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import java.util.Date;
+
+@Component
+@Log4j2
+@AllArgsConstructor
+@EnableMQMessageSender
+@EnableMQSelectorMessageListener
+public class MyMQSender implements RequestGateway {
+    private final MQMessageSender sender;
+    private final MQMessageSelectorListener listener;
+    private final ObjectMapper mapper;
+
+    @Override
+    public Mono<String> send(Request request) {
+        return sender.send(ctx -> {
+            String json;
+            try {
+                json = mapper.writeValueAsString(request);
+            } catch (JsonProcessingException e) {
+                throw new ParseMessageException(e);
+            }
+            return ctx.createTextMessage(json);
+        });
+    }
+
+    public Mono<Result> getResult(String correlationId) {
+        if (log.isInfoEnabled()) {
+            log.info("Received and processing");
+        }
+        return listener.getMessage(correlationId)
+                .map(this::extractResponse);
+    }
+
+    @SneakyThrows
+    private Result extractResponse(Message message) {
+        TextMessage textMessage = (TextMessage) message;
+        Request request = mapper.readValue(textMessage.getText(), Request.class);
+        Result result = Result.builder()
+                .request(request.getId())
+                .takenTime((new Date().getTime()) - request.getCreatedAt())
+                .build();
+        String id = message.getJMSMessageID();
+        if (log.isInfoEnabled()) {
+            log.info("Received with id: {}", id);
+        }
+        return result;
+    }
+}

--- a/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/entrypoints/Rest.java
+++ b/examples/mq-reactive-selector/src/main/java/co/com/bancolombia/jms/sample/selector/entrypoints/Rest.java
@@ -1,0 +1,32 @@
+package co.com.bancolombia.jms.sample.selector.entrypoints;
+
+import co.com.bancolombia.jms.sample.selector.domain.model.Result;
+import co.com.bancolombia.jms.sample.selector.domain.usecase.SampleUseCase;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Configuration
+@AllArgsConstructor
+public class Rest {
+    private final SampleUseCase sampleUseCase;
+
+    @Bean
+    public RouterFunction<ServerResponse> route() {
+        return RouterFunctions
+                .route(RequestPredicates.GET("/api/mq")
+                        .and(RequestPredicates.accept(MediaType.APPLICATION_JSON)), request -> sample());
+    }
+
+    public Mono<ServerResponse> sample() {
+        return ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(sampleUseCase.sendAndListen(), Result.class);
+    }
+}

--- a/examples/mq-reactive-selector/src/main/resources/application.yaml
+++ b/examples/mq-reactive-selector/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+server:
+  port: 8080
+spring:
+  application:
+    name: "mq-reactive"
+commons:
+  jms:
+    output-concurrency: 5
+    output-queue: "DEV.QUEUE.1"
+    producer-ttl: 60
+    reactive: true
+    input-concurrency: 5
+    input-queue: "DEV.QUEUE.2"
+    input-queue-alias: ""
+ibm:
+  mq:
+    channel: "DEV.APP.SVRCONN"
+    user: "app"
+    queue-manager: QM1


### PR DESCRIPTION
Features:
- **Allow use of receive to get specific message from a fixed queue**, this ability avoid the usage of temporary queues on horizontally self-scalable systems when the response should be received by the same instance.