### PR TITLE
Feature/set queue manager with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ application.yaml of your application.
 - `commons.jms.input-concurrency`: Equivalent to `concurrency` annotation property.
 - `commons.jms.input-queue`: Equivalent to `value` annotation property.
 - `commons.jms.input-queue-alias`: Equivalent to `tempQueueAlias` annotation property.
+- `input-queue-set-queue-manager`: Enable it to set queue manager using a temporary queue when needed.
 
 ### Sender properties
 

--- a/commons-jms-mq/src/main/java/co/com/bancolombia/commons/jms/mq/config/MQProperties.java
+++ b/commons-jms-mq/src/main/java/co/com/bancolombia/commons/jms/mq/config/MQProperties.java
@@ -15,6 +15,7 @@ public class MQProperties {
     private int inputConcurrency = DEFAULT_CONCURRENCY;
     private String inputQueue;
     private String inputQueueAlias;
+    private boolean inputQueueSetQueueManager = false;
     private long producerTtl = 0;
     private boolean reactive = false;
 }

--- a/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/models/MQListenerConfig.java
+++ b/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/internal/models/MQListenerConfig.java
@@ -4,6 +4,10 @@ import co.com.bancolombia.commons.jms.api.MQQueueCustomizer;
 import lombok.Builder;
 import lombok.Getter;
 
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+import java.util.function.BiConsumer;
+
 @Getter
 @Builder(toBuilder = true)
 public class MQListenerConfig {
@@ -20,4 +24,6 @@ public class MQListenerConfig {
     };
     @Builder.Default
     private final int maxRetries = -1; //NOSONAR
+    @Builder.Default
+    private final BiConsumer<JMSContext, Queue> qmSetter = (ctx, queue) -> {}; //NOSONAR
 }

--- a/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/utils/MQQueueUtils.java
+++ b/commons-jms-utils/src/main/java/co/com/bancolombia/commons/jms/utils/MQQueueUtils.java
@@ -4,7 +4,13 @@ import co.com.bancolombia.commons.jms.internal.models.MQListenerConfig;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import javax.jms.*;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+import javax.jms.JMSRuntimeException;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MQQueueUtils {
@@ -12,6 +18,9 @@ public class MQQueueUtils {
     public static Destination setupFixedQueue(JMSContext context, MQListenerConfig config) {
         Queue queue = context.createQueue(config.getQueue());
         customize(queue, config);
+        if (config.getQmSetter() != null) {
+            config.getQmSetter().accept(context, queue);
+        }
         return queue;
     }
 

--- a/examples/mq-reactive-selector/src/main/resources/application.yaml
+++ b/examples/mq-reactive-selector/src/main/resources/application.yaml
@@ -12,6 +12,7 @@ commons:
     input-concurrency: 5
     input-queue: "DEV.QUEUE.2"
     input-queue-alias: ""
+    input-queue-set-queue-manager: false # enable it to set queue manager using a temporary queue
 ibm:
   mq:
     channel: "DEV.APP.SVRCONN"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.5.0
+version=0.5.1
 springBootVersion=2.7.5
 gradleVersionsVersion=0.28.0
 mqJMSVersion=2.7.5


### PR DESCRIPTION
Features:
- Add option to automatically set the setBaseQueueManagerName for fixed queues

  The option is enabled in yaml configuration:
  ```yaml
  commons:
    jms:
      input-queue-set-queue-manager: true
   ```